### PR TITLE
Add missing comma in "/astory" code snippet

### DIFF
--- a/.vscode/atomicui.code-snippets
+++ b/.vscode/atomicui.code-snippets
@@ -146,7 +146,7 @@
 			"local Story = {",
 			"\tcontrols = {",
 			"\t\tVisible = true,",
-			"\t}",
+			"\t},",
 			"\trender = function(props)",
 			"\t\tlocal pane = ${TM_FILENAME_BASE/^(.*)\\..*/$1/}.new(props.target)",
 			"",


### PR DESCRIPTION
# Summary

This pull request makes a minor formatting fix to the `.vscode/atomicui.code-snippets` file, adding a missing comma after the `controls` table to ensure proper syntax.

# Affected instances
- 
